### PR TITLE
Change deprecated getargspec

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,41 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Python package
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        pip install --upgrade -e .[dev,doc,test]
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest

--- a/pyioc/providers.py
+++ b/pyioc/providers.py
@@ -36,7 +36,7 @@ def validate_if_callable_without_args(obj):
     else:
         obj_to_inspect = obj
 
-    spec = inspect.getargspec(obj_to_inspect)
+    spec = inspect.getfullargspec(obj_to_inspect)
     args = spec.args
     par_len = len(args)
     if par_len > 1:
@@ -105,11 +105,11 @@ class NewInstancesWithDepsProvider(ProviderBase):
     def _build_object(self, context):
         if inspect.isclass(self._callable_object):
             if _check_if_init_implemented(self._callable_object):
-                args = inspect.getargspec(self._callable_object.__init__).args
+                args = inspect.getfullargspec(self._callable_object.__init__).args
             else:
                 args = ()
         else:
-            args = inspect.getargspec(self._callable_object).args
+            args = inspect.getfullargspec(self._callable_object).args
 
         new_args = []
         for arg in args:

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,12 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5"
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ]
 )


### PR DESCRIPTION
inspect.getargspec() is deprecated in Python 3